### PR TITLE
Don't enable task lists with `.js-task-list-disabled` on `pageUpdate`

### DIFF
--- a/app/assets/javascripts/task_lists.coffee
+++ b/app/assets/javascripts/task_lists.coffee
@@ -151,4 +151,5 @@ $(document).on 'tasklist:enable', '.js-task-list-container', (event) ->
 
 $.pageUpdate ->
   $('.js-task-list-container').each ->
-    enableTaskList $(this)
+    $container = $(@)
+    enableTaskList $container unless $container.hasClass 'js-task-list-disabled'


### PR DESCRIPTION
Existing behavior is preserved, but if the `.js-task-list-disabled` class is present, the task list will have to be enabled manually with a trigger of `tasklist:enable` on the element in the DOM.

cc/ @github/task-lists 
