### PR TITLE
Add Bower package file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,19 +1,19 @@
 {
-  name: "task-lists",
-  version: "0.1.1",
-  dependencies: {
-    crema: ">= 0.10.4"
+  "name": "task-lists",
+  "version": "0.1.1",
+  "dependencies": {
+    "crema": ">= 0.10.4"
   },
-  devDependencies: {
-    qunit: ">= 1.0"
+  "devDependencies": {
+    "qunit": ">= 1.0"
   },
-  ignore: [
-  "lib/",
-  "script/",
-  "test/",
-  "vendor/",
-  ".gitignore",
-  "Gemfile",
-  "config.ru"
+  "ignore": [
+    "lib/",
+    "script/",
+    "test/",
+    "vendor/",
+    ".gitignore",
+    "Gemfile",
+    "config.ru"
   ]
 }


### PR DESCRIPTION
Setting things up so I can get this repo in internal projects. I already have it set up as a gem, and there are Ruby parts, so this might not be necessary if we can also handle adding the asset paths with the [Railtie](https://github.com/github/task-lists/blob/38170e3a52abe08eee6a3707e2047f028bf039cd/lib/task_list/railtie.rb) or something similar.

//cc @github/js 
