### PR TITLE
Support nested items

### DIFF
--- a/lib/task_list/filter.rb
+++ b/lib/task_list/filter.rb
@@ -47,20 +47,16 @@ class TaskList
       (?=\s)                  # followed by whitespace
     /x
 
-    ListSelector = [
-      # select UL/OL
-      ".//li[starts-with(text(),'[ ]')]/..",
-      ".//li[starts-with(text(),'[x]')]/..",
-      # and those wrapped in Ps
-      ".//li/p[1][starts-with(text(),'[ ]')]/../..",
-      ".//li/p[1][starts-with(text(),'[x]')]/../.."
-    ].join(' | ').freeze
+    ListItemSelector = ".//li[task_list_item(.)]".freeze
 
-    # Selects all LIs from a TaskList UL/OL
-    ItemSelector = ".//li".freeze
+    class XPathSelectorFunction
+      def self.task_list_item(nodes)
+        nodes if nodes.text =~ ItemPattern
+      end
+    end
 
     # Selects first P tag of an LI, if present
-    ItemParaSelector = ".//p[1]".freeze
+    ItemParaSelector = "./p[1]".freeze
 
     # List of `TaskList::Item` objects that were recognized in the document.
     # This is available in the result hash as `:task_list_items`.
@@ -100,20 +96,22 @@ class TaskList
     #
     # Returns an Array of Nokogiri::XML::Element objects for ordered and
     # unordered lists.
-    def task_lists
-      doc.xpath(ListSelector)
+    def list_items
+      doc.xpath(ListItemSelector, XPathSelectorFunction)
     end
 
-    # Public: filters a Nokogiri::XML::Element ordered/unordered list, marking
-    # up the list items in order to add behavior and include metadata.
+    # Filters the source for task list items.
     #
-    # Modifies the provided node.
+    # Each item is wrapped in HTML to identify, style, and layer
+    # useful behavior on top of.
+    #
+    # Modifications apply to the parsed document directly.
     #
     # Returns nothing.
-    def filter_list(node)
-      add_css_class(node, 'task-list')
+    def filter!
+      list_items.reverse.each do |li|
+        add_css_class(li.parent, 'task-list')
 
-      node.xpath(ItemSelector).reverse.each do |li|
         outer, inner =
           if p = li.xpath(ItemParaSelector)[0]
             [p, p.inner_html]
@@ -131,20 +129,6 @@ class TaskList
       end
     end
 
-    # Filters the source for task list items.
-    #
-    # Each item is wrapped in HTML to identify, style, and layer
-    # useful behavior on top of.
-    #
-    # Modifications apply to the parsed document directly.
-    #
-    # Returns nothing.
-    def filter!
-      task_lists.each do |node|
-        filter_list node
-      end
-    end
-
     def call
       filter!
       doc
@@ -154,6 +138,7 @@ class TaskList
     # names.
     def add_css_class(node, *new_class_names)
       class_names = (node['class'] || '').split(' ')
+      return if new_class_names.all? { |klass| class_names.include?(klass) }
       class_names.concat(new_class_names)
       node['class'] = class_names.uniq.join(' ')
     end

--- a/lib/task_list/version.rb
+++ b/lib/task_list/version.rb
@@ -1,3 +1,3 @@
 class TaskList
-  VERSION = [0, 2, 1].join('.')
+  VERSION = [0, 3, 0].join('.')
 end

--- a/test/task_list/filter_test.rb
+++ b/test/task_list/filter_test.rb
@@ -100,6 +100,7 @@ class TaskList::FilterTest < Minitest::Test
   - [ ] two.two
 - [ ] three
     md
+
     assert_equal 6 + 2, filter(text)[:output].css('.task-list-item .task-list-item').size
     assert_equal 2, filter(text)[:output].css('.task-list-item .task-list-item .task-list-item').size
   end


### PR DESCRIPTION
Nested lists are pretty standard in Markdown and make a lot of sense for Task Lists especially. Right now, though, they don't render properly and don't handle updates either. Essentially, they're not supported but they should be,.

This just gets the pull started for this feature. There are some technical problems that need to be worked out first which this first commit should help demonstrate.
- [ ] fix XPath selector to only select top-level items
- [ ] recursively select nested items to be filtered
- [ ] ensure updates work correctly (via JS tests)

//cc @github/task-lists @aspires 

---

**UPDATE**: instead of the recursive method, I've found that if we filter LIs in reverse order, the result is a depth-first approach which fixes the problem. Simple and elegant, without any recursion. And in the process, simplified the selectors and methods quite a bit while opening up more flexible pattern matching! :sunglasses: 
