### PR TITLE
Update Crema fire require

### DIFF
--- a/app/assets/javascripts/task_lists.coffee
+++ b/app/assets/javascripts/task_lists.coffee
@@ -5,7 +5,7 @@
 #= provides tasklist:change
 #= provides tasklist:changed
 #
-#= require crema/element/fire
+#= require crema/events/fire
 #= require crema/events/pageupdate
 #
 # Enables Task List update behavior.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -11,5 +11,5 @@ if ! npm list bower 2>&1 | grep 0.8.5 >/dev/null; then
 fi
 
 bower install --no-color jquery
-bower install --no-color https://hubot:VwUWoC6XsDucCLxhHZZzZCVa2xE@github.com/github/crema.git
+bower install --no-color https://github.com/github/crema.git
 bower install --no-color rails-behaviors

--- a/script/cibuild
+++ b/script/cibuild
@@ -7,6 +7,10 @@
 cd $(dirname "$0")/..
 export PATH="$(pwd)/bin:$(pwd)/script:$(pwd)/node_modules/.bin:/usr/share/rbenv/shims:/opt/phantomjs/bin:/usr/share/nvm/0.8.11/bin:$PATH"
 
+# setup Ruby version
+if [ -d /usr/share/rbenv/shims ]; then export PATH=/usr/share/rbenv/shims:$PATH; fi
+export RBENV_VERSION="1.9.3-p231-tcs-github"
+
 # Write commit we're building at
 git log -n 1 || true
 echo


### PR DESCRIPTION
We're shuffling around `require`s in crema, trying to get rid of the `utils` and `element/` directories. As of crema 0.23.0, `crema/element/fire` is now `crema/events/fire`.

/cc @mtodd 
