### PR TITLE
Rewrite Filter: use XPath function recursively

### DIFF
--- a/test/task_list/filter_test.rb
+++ b/test/task_list/filter_test.rb
@@ -83,7 +83,8 @@ class TaskList::FilterTest < Minitest::Test
 - [ ] one
   - [ ] one.one
     md
-    assert item = filter(text)[:output].css('.task-list-item .task-list-item').pop
+    item = filter(text)[:output].css('.task-list-item .task-list-item').pop
+    assert item, "nested item expected"
   end
 
   def test_handles_complicated_nested_items


### PR DESCRIPTION
Simplifies the filter, recursively filtering task lists, depth first.

This removes the need to `reverse` the item list in order to support nested task lists.

This is a companion/alternative to #21. I'm not crazy about the recursion: I'd rather have an intuitive `reverse` than have to query N+1 times, even if it is fast. But I can be swayed.

Refer to #21 for some remarks on the code, but feel free to comment inline here too.

cc @github/task-lists @jbarnette 
