### PR TITLE
Enable TravisCI build dependency caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 notifications:
   email: false
 cache:
-  bundler: true
   directories:
+    - vendor/bundle
     - node_modules
     - bower_components


### PR DESCRIPTION
Not sure if this will work when this is a public repo, but let's give it a whirl.
