### PR TITLE
Accidentally a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Read through the documented behaviors and samples [in the source][frontend_behav
 
 ## Installation
 
-Task Lists are packaged as both a RubyGem with both backend and frontend behavior, and a Bower package wiht just the frontend behavior.
+Task Lists are packaged as both a RubyGem with both backend and frontend behavior, and a Bower package with just the frontend behavior.
 
 ### Backend: RubyGem
 


### PR DESCRIPTION
Typing too fast :dash: ended up with two letters transposed.

I typed it **way slower**
