### PR TITLE
Predicate complete? should return boolean.

### DIFF
--- a/lib/task_list.rb
+++ b/lib/task_list.rb
@@ -25,8 +25,20 @@ class TaskList
 
   class Item < Struct.new(:checkbox_text, :source)
     Complete = /\[[xX]\]/.freeze # see TaskList::Filter
+
+    # Public: Check if a task list is complete.
+    #
+    # Examples
+    #
+    #   Item.new(checkbox_text: "- [x]").complete?
+    #   # => true
+    #
+    #   Item.new(checkbox_text: "- [ ]").complete?
+    #   # => false
+    #
+    # Returns true for checked list, false otherwise
     def complete?
-      checkbox_text =~ Complete
+      !!(checkbox_text =~ Complete)
     end
   end
 end


### PR DESCRIPTION
Hello,

IMHO I think when people use `complete?`, they expect to get `true` or `false` instead of `0` and `nil` :open_mouth:.

What do you think?

Also I would say that this method should called `completed?` :innocent:, but this will require a minor version bump. 

Thanks! 