### PR TITLE
Remove TaskList::Item#source

### DIFF
--- a/lib/task_list.rb
+++ b/lib/task_list.rb
@@ -23,7 +23,7 @@ class TaskList
     @summary ||= TaskList::Summary.new(record.task_list_items)
   end
 
-  class Item < Struct.new(:checkbox_text, :source)
+  class Item < Struct.new(:checkbox_text)
     Complete = /\[[xX]\]/.freeze # see TaskList::Filter
 
     # Public: Check if a task list is complete.

--- a/lib/task_list/filter.rb
+++ b/lib/task_list/filter.rb
@@ -90,9 +90,9 @@ class TaskList
     # See [this pull](https://github.com/github/github/pull/8505) for details.
     #
     # Returns the marked up task list item Nokogiri::XML::NodeSet object.
-    def render_task_list_item(item)
+    def render_task_list_item(item, html)
       Nokogiri::HTML.fragment \
-        item.source.sub(ItemPattern, render_item_checkbox(item)), 'utf-8'
+        html.sub(ItemPattern, render_item_checkbox(item)), 'utf-8'
     end
 
     # Public: Select all task lists from the `doc`.
@@ -122,12 +122,12 @@ class TaskList
             [li, li.inner_html]
           end
         if match = (inner.chomp =~ ItemPattern && $1)
-          item = TaskList::Item.new(match, inner)
+          item = TaskList::Item.new(match)
           # prepend because we're iterating in reverse
           task_list_items.unshift item
 
           add_css_class(li, 'task-list-item')
-          outer.inner_html = render_task_list_item(item)
+          outer.inner_html = render_task_list_item(item, inner)
         end
       end
     end

--- a/test/task_list/summary_test.rb
+++ b/test/task_list/summary_test.rb
@@ -4,8 +4,8 @@ require 'task_list/summary'
 
 class TaskList::SummaryTest < Minitest::Test
   def setup
-    @complete   = make_item "[x]", "complete"
-    @incomplete = make_item "[ ]", "incomplete"
+    @complete   = make_item "[x]"
+    @incomplete = make_item "[ ]"
     @items = [@complete, @incomplete]
     @summary = make_summary @items
   end
@@ -30,8 +30,8 @@ class TaskList::SummaryTest < Minitest::Test
 
   protected
 
-  def make_item(checkbox_text = "[ ]", source = "an item!")
-    TaskList::Item.new(checkbox_text, source)
+  def make_item(checkbox_text = "[ ]")
+    TaskList::Item.new(checkbox_text)
   end
 
   def make_summary(items)

--- a/test/task_list_test.rb
+++ b/test/task_list_test.rb
@@ -16,12 +16,12 @@ class TaskListTest < Minitest::Test
   end
 
   def test_complete_item
-    item = TaskList::Item.new("[x]", "complete")
+    item = TaskList::Item.new("[x]")
     assert item.complete?, "expected to be complete"
   end
 
   def test_incomplete_item
-    item = TaskList::Item.new("[ ]", "incomplete")
+    item = TaskList::Item.new("[ ]")
     assert !item.complete?, "expected to be incomplete"
   end
 


### PR DESCRIPTION
This isn't used at all in the github.com Rails app.

/cc @mtodd 
