### PR TITLE
Don't add task-list class to lists that don't contain tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Rendered HTML (the `<ul>` element below) should be contained in a `js-task-list-
 <div class="js-task-list-container">
   <ul class="task-list">
     <li class="task-list-item">
-      <input type="checkbox" class="js-task-list-item-checkbox" disabled />
+      <input type="checkbox" class="task-list-item-checkbox" disabled />
       text
     </li>
   </ul>

--- a/app/assets/javascripts/task_list.coffee
+++ b/app/assets/javascripts/task_list.coffee
@@ -14,7 +14,7 @@
 #   <div class="js-task-list-container">
 #     <ul class="task-list">
 #       <li class="task-list-item">
-#         <input type="checkbox" class="js-task-list-item-checkbox" disabled />
+#         <input type="checkbox" class="task-list-item-checkbox" disabled />
 #         text
 #       </li>
 #     </ul>

--- a/lib/task_list/filter.rb
+++ b/lib/task_list/filter.rb
@@ -113,8 +113,6 @@ class TaskList
     # Returns nothing.
     def filter!
       list_items.reverse.each do |li|
-        add_css_class(li.parent, 'task-list')
-
         outer, inner =
           if p = li.xpath(ItemParaSelector)[0]
             [p, p.inner_html]
@@ -122,6 +120,8 @@ class TaskList
             [li, li.inner_html]
           end
         if match = (inner.chomp =~ ItemPattern && $1)
+          add_css_class(li.parent, 'task-list')
+
           item = TaskList::Item.new(match, inner)
           # prepend because we're iterating in reverse
           task_list_items.unshift item

--- a/test/task_list/filter_test.rb
+++ b/test/task_list/filter_test.rb
@@ -133,6 +133,15 @@ class TaskList::FilterTest < Minitest::Test
     assert_equal 2, filter(text)[:output].css("[checked]").size
   end
 
+  def test_no_class_on_generic_list
+    text = <<-md
+- Item one
+- Item two
+    md
+
+    assert_equal 0, filter(text)[:output].css('ul.task-list').size
+  end
+
   protected
 
   def filter(input, context = @context, result = nil)


### PR DESCRIPTION
The filter was adding the `task-list` class to all list elements regardless of
whether or not they contained task lists.