### PR TITLE
Fix normal list class

### DIFF
--- a/lib/task_list/filter.rb
+++ b/lib/task_list/filter.rb
@@ -113,8 +113,6 @@ class TaskList
     # Returns nothing.
     def filter!
       list_items.reverse.each do |li|
-        add_css_class(li.parent, 'task-list')
-
         outer, inner =
           if p = li.xpath(ItemParaSelector)[0]
             [p, p.inner_html]
@@ -122,6 +120,8 @@ class TaskList
             [li, li.inner_html]
           end
         if match = (inner.chomp =~ ItemPattern && $1)
+          add_css_class(li.parent, 'task-list')
+
           item = TaskList::Item.new(match, inner)
           # prepend because we're iterating in reverse
           task_list_items.unshift item

--- a/test/task_list/filter_test.rb
+++ b/test/task_list/filter_test.rb
@@ -13,6 +13,14 @@ class TaskList::FilterTest < Minitest::Test
     @item_selector = "input.task-list-item-checkbox[type=checkbox]"
   end
 
+  def test_normal_list
+    text = <<-md
+- item 1
+- item 2
+    md
+    assert_equal 0, filter(text)[:output].css("ul.task-list").size
+  end
+
   def test_filters_items_in_a_list
     text = <<-md
 - [ ] incomplete


### PR DESCRIPTION
task_list filter should not add `ul.task-list` class for normal list, this patch fix it.